### PR TITLE
Backward compatible UA check for Safari

### DIFF
--- a/src/utils/userAgent.js
+++ b/src/utils/userAgent.js
@@ -12,4 +12,4 @@ const getBrowser = () => {
 
 export const isMobileOrTablet = isMobileDevice() || isTabletDevice();
 export const isMobileOrTabletSafari =
-  typeof window !== 'undefined' && isMobileOrTablet && getBrowser().name.includes('Safari');
+  typeof window !== 'undefined' && isMobileOrTablet && getBrowser().name.indexOf('Safari') >= 0;


### PR DESCRIPTION
The includes method only works from Safari 9 on.