### PR TITLE
Remove ua-parser.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "desktop",
     "tablet"
   ],
-  "dependencies": {
-    "ua-parser-js": "^0.7.17"
-  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.1",

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -1,10 +1,4 @@
-// @flow
-import UAParser from 'ua-parser-js';
-// Adopted and modified solution from Bohdan Didukh (2017)
-// https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi
-
-const parser = new UAParser();
-const isIosDevice = typeof window !== 'undefined' && parser.getOS().name === 'iOS';
+const isIosDevice = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
 
 type HandleScrollEvent = TouchEvent;
 


### PR DESCRIPTION
Uaparser ist about ~11KB when minified / ~4KB gzipped. My complete preact application size is about 30KB. So UAParser is more than 10% of the application. As I see the only reason why you use uaparser is to detect whether the device is IOS or not.. This should also work without UAParser.

https://stackoverflow.com/questions/9038625/detect-if-device-is-ios