### PR TITLE
Fix multiple disable/enable scroll on iOS device

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -14,7 +14,7 @@ const isIosDevice =
 type HandleScrollEvent = TouchEvent;
 
 let firstTargetElement: any = null;
-const allTargetElements: { [any]: any } = [];
+let allTargetElements: [any] = [];
 let initialClientY: number = -1;
 let previousBodyOverflowSetting;
 let previousDocumentElementOverflowSetting;

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -14,7 +14,7 @@ const isIosDevice =
 type HandleScrollEvent = TouchEvent;
 
 let firstTargetElement: any = null;
-const allTargetElements: { [any]: any } = {};
+const allTargetElements: { [any]: any } = [];
 let initialClientY: number = -1;
 let previousBodyOverflowSetting;
 let previousDocumentElementOverflowSetting;
@@ -100,8 +100,8 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
   if (isIosDevice) {
     // targetElement must be provided, and disableBodyScroll must not have been
     // called on this targetElement before.
-    if (targetElement && !allTargetElements[targetElement]) {
-      allTargetElements[targetElement] = targetElement;
+    if (targetElement && !allTargetElements.includes(targetElement)) {
+      allTargetElements = [...allTargetElements, targetElement];
 
       targetElement.ontouchstart = (event: HandleScrollEvent) => {
         if (event.targetTouches.length === 1) {
@@ -126,11 +126,11 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
 export const clearAllBodyScrollLocks = (): void => {
   if (isIosDevice) {
     // Clear all allTargetElements ontouchstart/ontouchmove handlers, and the references
-    Object.entries(allTargetElements).forEach(([key, targetElement]: [any, any]) => {
+    allTargetElements.forEach((targetElement: any) => {
       targetElement.ontouchstart = null;
       targetElement.ontouchmove = null;
 
-      delete allTargetElements[key];
+      allTargetElements = [];
     });
 
     // Reset initial clientY
@@ -146,6 +146,10 @@ export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;
+    
+    allTargetElements = allTargetElements.filter(
+      elem => elem !== targetElement,
+    );
   } else if (firstTargetElement === targetElement) {
     restoreOverflowSetting();
 


### PR DESCRIPTION
When performing multiple disable/enable scroll on a row on an iOS device, the code was not working because :
- allTargetElements[targetElement] was basically doing targetElement.toString(), which resulted in something like `"[object HTMLDivElement]"`
- targetElement was nos removed when invoking `enableBodyScroll`

This fix uses an array, which stores `targetElement`s references to compare them easily.

Tested on an iOS device and works. Please let me know if you want me to change anything!

Also, thanks for this great lib.