### PR TITLE
Use addEventListener to support iOS 11

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -104,13 +104,13 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
           initialClientY = event.targetTouches[0].clientY;
         }
       };
-      targetElement.ontouchmove = (event: HandleScrollEvent) => {
+      targetElement.lockBodyScroll = (event: HandleScrollEvent) => {
         if (event.targetTouches.length === 1) {
           // detect single touch
           handleScroll(event, targetElement);
         }
       };
-      targetElement.addEventListener('touchmove', targetElement.ontouchmove, {
+      targetElement.addEventListener('touchmove', targetElement.lockBodyScroll, {
         passive: false,
       });
     }
@@ -126,10 +126,10 @@ export const clearAllBodyScrollLocks = (): void => {
     // Clear all allTargetElements ontouchstart/ontouchmove handlers, and the references
     allTargetElements.forEach((targetElement: any) => {
       targetElement.ontouchstart = null;
-      targetElement.removeEventListener('touchmove', targetElement.ontouchmove, {
+      targetElement.removeEventListener('touchmove', targetElement.lockBodyScroll, {
         passive: false,
       });
-      targetElement.ontouchmove = null;
+      targetElement.lockBodyScroll = null;
     });
 
     allTargetElements = [];
@@ -146,10 +146,10 @@ export const clearAllBodyScrollLocks = (): void => {
 export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
     targetElement.ontouchstart = null;
-    targetElement.removeEventListener('touchmove', targetElement.ontouchmove, {
+    targetElement.removeEventListener('touchmove', targetElement.lockBodyScroll, {
       passive: false,
     });
-    targetElement.ontouchmove = null;
+    targetElement.lockBodyScroll = null;
 
     allTargetElements = allTargetElements.filter(element => element !== targetElement);
   } else if (firstTargetElement === targetElement) {

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -110,7 +110,7 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
           handleScroll(event, targetElement);
         }
       };
-      targetElement.addEventListener('touchmove', targetElement.lockBodyScroll, {
+      document.addEventListener('touchmove', targetElement.lockBodyScroll, {
         passive: false,
       });
     }
@@ -126,7 +126,7 @@ export const clearAllBodyScrollLocks = (): void => {
     // Clear all allTargetElements ontouchstart/ontouchmove handlers, and the references
     allTargetElements.forEach((targetElement: any) => {
       targetElement.ontouchstart = null;
-      targetElement.removeEventListener('touchmove', targetElement.lockBodyScroll, {
+      document.removeEventListener('touchmove', targetElement.lockBodyScroll, {
         passive: false,
       });
       targetElement.lockBodyScroll = null;
@@ -146,7 +146,7 @@ export const clearAllBodyScrollLocks = (): void => {
 export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
     targetElement.ontouchstart = null;
-    targetElement.removeEventListener('touchmove', targetElement.lockBodyScroll, {
+    document.removeEventListener('touchmove', targetElement.lockBodyScroll, {
       passive: false,
     });
     targetElement.lockBodyScroll = null;

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -110,6 +110,9 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
           handleScroll(event, targetElement);
         }
       };
+      targetElement.addEventListener('touchmove', targetElement.ontouchmove, {
+        passive: false,
+      });
     }
   } else {
     setOverflowHidden(options);
@@ -123,6 +126,9 @@ export const clearAllBodyScrollLocks = (): void => {
     // Clear all allTargetElements ontouchstart/ontouchmove handlers, and the references
     allTargetElements.forEach((targetElement: any) => {
       targetElement.ontouchstart = null;
+      targetElement.removeEventListener('touchmove', targetElement.ontouchmove, {
+        passive: false,
+      });
       targetElement.ontouchmove = null;
     });
 
@@ -140,6 +146,9 @@ export const clearAllBodyScrollLocks = (): void => {
 export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
     targetElement.ontouchstart = null;
+    targetElement.removeEventListener('touchmove', targetElement.ontouchmove, {
+      passive: false,
+    });
     targetElement.ontouchmove = null;
 
     allTargetElements = allTargetElements.filter(element => element !== targetElement);


### PR DESCRIPTION
Not sure if this doubles up on listeners, since it's both assigning to `targetElement.ontouchmove` and calling `addEventListener`, but this should help iOS 11.

Fixes #27 