### PR TITLE
Fixed scroll lock on iOS 11.3+

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -114,13 +114,7 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
       };
 
       if (!documentListenerAdded) {
-        document.addEventListener(
-          'touchmove',
-          e => {
-            e.preventDefault();
-          },
-          { passive: false }
-        );
+        document.addEventListener('touchmove', e => e.preventDefault(), { passive: false });
         documentListenerAdded = true;
       }
     }
@@ -140,13 +134,7 @@ export const clearAllBodyScrollLocks = (): void => {
     });
 
     if (documentListenerAdded) {
-      document.removeEventListener(
-        'touchmove',
-        e => {
-          e.preventDefault();
-        },
-        { passive: false }
-      );
+      document.removeEventListener('touchmove', e => e.preventDefault(), { passive: false });
       documentListenerAdded = false;
     }
 
@@ -167,13 +155,7 @@ export const enableBodyScroll = (targetElement: any): void => {
     targetElement.ontouchmove = null;
 
     if (documentListenerAdded) {
-      document.removeEventListener(
-        'touchmove',
-        e => {
-          e.preventDefault();
-        },
-        { passive: false }
-      );
+      document.removeEventListener('touchmove', e => e.preventDefault(), { passive: false });
       documentListenerAdded = false;
     }
 

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -15,6 +15,7 @@ type HandleScrollEvent = TouchEvent;
 
 let firstTargetElement: HTMLElement | null = null;
 let allTargetElements: Array<HTMLElement> = [];
+let documentListenerAdded: boolean = false;
 let initialClientY: number = -1;
 let previousBodyOverflowSetting;
 let previousBodyPaddingRight;
@@ -88,6 +89,7 @@ const handleScroll = (event: HandleScrollEvent, targetElement: any): boolean => 
     return preventDefault(event);
   }
 
+  event.stopPropagation();
   return true;
 };
 
@@ -110,6 +112,17 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
           handleScroll(event, targetElement);
         }
       };
+
+      if (!documentListenerAdded) {
+        document.addEventListener(
+          'touchmove',
+          e => {
+            e.preventDefault();
+          },
+          { passive: false }
+        );
+        documentListenerAdded = true;
+      }
     }
   } else {
     setOverflowHidden(options);
@@ -126,6 +139,17 @@ export const clearAllBodyScrollLocks = (): void => {
       targetElement.ontouchmove = null;
     });
 
+    if (documentListenerAdded) {
+      document.removeEventListener(
+        'touchmove',
+        e => {
+          e.preventDefault();
+        },
+        { passive: false }
+      );
+      documentListenerAdded = false;
+    }
+
     allTargetElements = [];
 
     // Reset initial clientY
@@ -141,6 +165,17 @@ export const enableBodyScroll = (targetElement: any): void => {
   if (isIosDevice) {
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;
+
+    if (documentListenerAdded) {
+      document.removeEventListener(
+        'touchmove',
+        e => {
+          e.preventDefault();
+        },
+        { passive: false }
+      );
+      documentListenerAdded = false;
+    }
 
     allTargetElements = allTargetElements.filter(element => element !== targetElement);
   } else if (firstTargetElement === targetElement) {

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -114,7 +114,7 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
       };
 
       if (!documentListenerAdded) {
-        document.addEventListener('touchmove', e => e.preventDefault(), { passive: false });
+        document.addEventListener('touchmove', preventDefault, { passive: false });
         documentListenerAdded = true;
       }
     }
@@ -134,7 +134,7 @@ export const clearAllBodyScrollLocks = (): void => {
     });
 
     if (documentListenerAdded) {
-      document.removeEventListener('touchmove', e => e.preventDefault(), { passive: false });
+      document.removeEventListener('touchmove', preventDefault, { passive: false });
       documentListenerAdded = false;
     }
 
@@ -155,7 +155,7 @@ export const enableBodyScroll = (targetElement: any): void => {
     targetElement.ontouchmove = null;
 
     if (documentListenerAdded) {
-      document.removeEventListener('touchmove', e => e.preventDefault(), { passive: false });
+      document.removeEventListener('touchmove', preventDefault, { passive: false });
       documentListenerAdded = false;
     }
 

--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -154,12 +154,12 @@ export const enableBodyScroll = (targetElement: any): void => {
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;
 
-    if (documentListenerAdded) {
+    allTargetElements = allTargetElements.filter(element => element !== targetElement);
+
+    if (documentListenerAdded && allTargetElements.length === 0) {
       document.removeEventListener('touchmove', preventDefault, { passive: false });
       documentListenerAdded = false;
     }
-
-    allTargetElements = allTargetElements.filter(element => element !== targetElement);
   } else if (firstTargetElement === targetElement) {
     restoreOverflowSetting();
 


### PR DESCRIPTION
When disabling the body scroll it is not working on iOS 11.3+ because the document listeners are all passive with the purpose of making the scrolling smoother. This means, the `document` does not wait for the `e.preventDefault()` as it assumes this method will never be called. This behaviour is intended and other browsers such as Chrome already have it this way as well.

References: 
1. https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
2. https://stackoverflow.com/questions/49500339/cant-prevent-touchmove-from-scrolling-window-on-ios

This solution adds a non-passive `touchmove` event listener to the `document` so it prevents the `body` scrolling on new iOS devices. It also prevents the propagation from the `targetElement` so it does not get affected by the aforementioned listener.

Tested on a real device: iPhone 8S iOS: 11.4.1

Fixes: #27 