### PR TITLE
Feature detect passive event listener support for iOS 9

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -6,6 +6,16 @@ export interface BodyScrollOptions {
   reserveScrollBarGap?: boolean;
 }
 
+// Older browsers don't support event options, feature detect it.
+let hasPassiveEvents = false;
+const passiveTestOptions = {
+  get passive() {
+    hasPassiveEvents = true;
+  },
+};
+window.addEventListener('testPassive', null, passiveTestOptions);
+window.removeEventListener('testPassive', null, passiveTestOptions);
+
 const isIosDevice =
   typeof window !== 'undefined' &&
   window.navigator &&
@@ -114,7 +124,7 @@ export const disableBodyScroll = (targetElement: any, options?: BodyScrollOption
       };
 
       if (!documentListenerAdded) {
-        document.addEventListener('touchmove', preventDefault, { passive: false });
+        document.addEventListener('touchmove', preventDefault, hasPassiveEvents ? { passive: false } : undefined);
         documentListenerAdded = true;
       }
     }
@@ -134,7 +144,7 @@ export const clearAllBodyScrollLocks = (): void => {
     });
 
     if (documentListenerAdded) {
-      document.removeEventListener('touchmove', preventDefault, { passive: false });
+      document.removeEventListener('touchmove', preventDefault, hasPassiveEvents ? { passive: false } : undefined);
       documentListenerAdded = false;
     }
 
@@ -157,7 +167,7 @@ export const enableBodyScroll = (targetElement: any): void => {
     allTargetElements = allTargetElements.filter(element => element !== targetElement);
 
     if (documentListenerAdded && allTargetElements.length === 0) {
-      document.removeEventListener('touchmove', preventDefault, { passive: false });
+      document.removeEventListener('touchmove', preventDefault, hasPassiveEvents ? { passive: false } : undefined);
       documentListenerAdded = false;
     }
   } else if (firstTargetElement === targetElement) {


### PR DESCRIPTION
iOS 9 does not support event options, so the options argument is interpreted as registering capturing event. This causes the body touchmove listener to also pick up events from the scroll target element which causes scrolling inside the target element to also be cancelled.

Feature detecting event listener options is a bit awkward, but it works. Tested on iOS 9, 10 and 11.

Fixed https://github.com/willmcpo/body-scroll-lock/issues/38 

I didn't commit the compiled version or create a release, not sure what workflow you prefer.
