### PR TITLE
Add "module" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.6.1",
   "description": "Enables body scroll locking (for iOS Mobile and Tablet, Android, desktop Safari/Chrome/Firefox) without breaking scrolling of a target element (eg. modal/lightbox/flyouts/nav-menus)",
   "main": "lib/bodyScrollLock.min.js",
+  "module": "lib/bodyScrollLock.es6.js",
   "author": "Will Po",
   "repository": "https://github.com/willmcpo/body-scroll-lock.git",
   "license": "MIT",


### PR DESCRIPTION
I just ran into issue #79. The README states that React/ES6 users can use the library as such:

```js
import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
```

While that may be true in some situations, you may need to explicitly reference the `es6` file in other cases.

```js
import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock/lib/bodyScrollLock.es6.js';
```

By adding a `module` field to `package.json` pointing to `lib/bodyScrollLock.es6.js`, tools like Rollup and Webpack can automatically resolve the `esm` version of this package.

**More Information**
[Rollup Wiki](https://github.com/rollup/rollup/wiki/pkg.module)
[Stackoverflow](https://stackoverflow.com/a/47537198)