### PR TITLE
chore(package.json): add "files" to avoid publishing unnecessary files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Will Po",
   "repository": "https://github.com/willmcpo/body-scroll-lock.git",
   "license": "MIT",
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "body scroll",
     "body scroll lock",


### PR DESCRIPTION
Currently, unnecessary files are published to npm:

![image](https://user-images.githubusercontent.com/6059356/58164918-69e08480-7c8f-11e9-9422-dfc77a290ad0.png)

This PR will fix that and help against creating objects heavier than a black hole

![image](https://user-images.githubusercontent.com/6059356/58165093-b4620100-7c8f-11e9-8941-8b5bd04bf9c4.png)


Docs: https://docs.npmjs.com/files/package.json#files

> Certain files are always included, regardless of settings:
>
> - package.json
> - README
> - CHANGES / CHANGELOG / HISTORY
> - LICENSE / LICENCE
> - NOTICE
> - The file in the “main” field