### PR TITLE
innerRef as props instead ref to pass properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,185 +1,184 @@
 <p align="left"> <img width="675" src="https://raw.githubusercontent.com/willmcpo/body-scroll-lock/master/images/logo.png" alt="Body scroll lock...just works with everything ;-)" /> </p>
 
 ## Why BSL?
+
 Enables body scroll locking (for iOS Mobile and Tablet, Android, desktop Safari/Chrome/Firefox) without breaking scrolling of a target element (eg. modal/lightbox/flyouts/nav-menus).
 
-*Features:*
+_Features:_
 
 - disables body scroll WITHOUT disabling scroll of a target element
 - works on iOS mobile/tablet (!!)
 - works on Android
 - works on Safari desktop
-- works on Chrome/Firefox 
+- works on Chrome/Firefox
 - works with vanilla JS and frameworks such as React / Angular / VueJS
 - supports nested target elements (eg. a modal that appears on top of a flyout)
 - can reserve scrollbar width
 - `-webkit-overflow-scrolling: touch` still works
 
-*Aren't the alternative approaches sufficient?*
+_Aren't the alternative approaches sufficient?_
 
 - the approach `document.body.ontouchmove = (e) => { e.preventDefault(); return false; };` locks the
-body scroll, but ALSO locks the scroll of a target element (eg. modal).
+  body scroll, but ALSO locks the scroll of a target element (eg. modal).
 - the approach `overflow: hidden` on the body or html elements doesn't work for all browsers
 - the `position: fixed` approach causes the body scroll to reset
 - some approaches break inertia/momentum/rubber-band scrolling on iOS
 
-*Package Size:*
+_Package Size:_
 
 - LIGHT - package is only 2.8KB and 1.1KB when gzipped (see [here](https://bundlephobia.com/result?p=body-scroll-lock))!
 
 ## Install
 
     $ yarn add body-scroll-lock
-    
-    or
-    
-    $ npm install body-scroll-lock
-    
-    
-    
-You can also load via a `<script src="lib/bodyScrollLock.js"></script>` tag (refer to the lib folder).
 
+    or
+
+    $ npm install body-scroll-lock
+
+You can also load via a `<script src="lib/bodyScrollLock.js"></script>` tag (refer to the lib folder).
 
 ## Usage examples
 
 ##### Common JS
+
 ```javascript
 // 1. Import the functions
-const bodyScrollLock = require('body-scroll-lock');
+const bodyScrollLock = require("body-scroll-lock");
 const disableBodyScroll = bodyScrollLock.disableBodyScroll;
 const enableBodyScroll = bodyScrollLock.enableBodyScroll;
-  
-// 2. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav). 
+
+// 2. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav).
 // Specifically, the target element is the one we would like to allow scroll on (NOT a parent of that element).
 // This is also the element to apply the CSS '-webkit-overflow-scrolling: touch;' if desired.
 const targetElement = document.querySelector("#someElementId");
-  
-  
+
 // 3. ...in some event handler after showing the target element...disable body scroll
 disableBodyScroll(targetElement);
- 
- 
+
 // 4. ...in some event handler after hiding the target element...
 enableBodyScroll(targetElement);
 ```
-  
-  
+
 ##### React/ES6
+
 ```javascript
 // 1. Import the functions
-import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
-  
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+  clearAllBodyScrollLocks
+} from "body-scroll-lock";
+
 class SomeComponent extends React.Component {
   targetElement = null;
-  
+
   componentDidMount() {
-    // 2. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav). 
+    // 2. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav).
     // Specifically, the target element is the one we would like to allow scroll on (NOT a parent of that element).
     // This is also the element to apply the CSS '-webkit-overflow-scrolling: touch;' if desired.
-    this.targetElement = document.querySelector('#targetElementId');
+    this.targetElement = document.querySelector("#targetElementId");
   }
-  
+
   showTargetElement = () => {
     // ... some logic to show target element
-    
+
     // 3. Disable body scroll
     disableBodyScroll(this.targetElement);
   };
-  
+
   hideTargetElement = () => {
     // ... some logic to hide target element
-    
+
     // 4. Re-enable body scroll
     enableBodyScroll(this.targetElement);
-  }
-  
+  };
+
   componentWillUnmount() {
     // 5. Useful if we have called disableBodyScroll for multiple target elements,
     // and we just want a kill-switch to undo all that.
-    // OR useful for if the `hideTargetElement()` function got circumvented eg. visitor 
+    // OR useful for if the `hideTargetElement()` function got circumvented eg. visitor
     // clicks a link which takes him/her to a different page within the app.
     clearAllBodyScrollLocks();
   }
 
-  render() {   
-    return (
-      <div>
-        some JSX to go here
-      </div> 
-    );
+  render() {
+    return <div>some JSX to go here</div>;
   }
 }
 ```
 
 ##### React/ES6 with Refs
+
 ```javascript
 // 1. Import the functions
-import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
-  
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+  clearAllBodyScrollLocks
+} from "body-scroll-lock";
+
 class SomeComponent extends React.Component {
   // 2. Initialise your ref and targetElement here
   targetRef = React.createRef();
   targetElement = null;
 
   componentDidMount() {
-    // 3. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav). 
+    // 3. Get a target element that you want to persist scrolling for (such as a modal/lightbox/flyout/nav).
     // Specifically, the target element is the one we would like to allow scroll on (NOT a parent of that element).
     // This is also the element to apply the CSS '-webkit-overflow-scrolling: touch;' if desired.
-    this.targetElement = this.targetRef.current; 
+    this.targetElement = this.targetRef.current;
   }
-  
+
   showTargetElement = () => {
     // ... some logic to show target element
-    
+
     // 4. Disable body scroll
     disableBodyScroll(this.targetElement);
   };
-  
+
   hideTargetElement = () => {
     // ... some logic to hide target element
-    
+
     // 5. Re-enable body scroll
     enableBodyScroll(this.targetElement);
-  }
-  
+  };
+
   componentWillUnmount() {
     // 5. Useful if we have called disableBodyScroll for multiple target elements,
     // and we just want a kill-switch to undo all that.
-    // OR useful for if the `hideTargetElement()` function got circumvented eg. visitor 
+    // OR useful for if the `hideTargetElement()` function got circumvented eg. visitor
     // clicks a link which takes him/her to a different page within the app.
     clearAllBodyScrollLocks();
   }
 
-  render() {   
+  render() {
     return (
       // 6. Pass your ref with the reference to the targetElement to SomeOtherComponent
-      <SomeOtherComponent ref={this.targetRef}>
+      <SomeOtherComponent innerRef={this.targetRef}>
         some JSX to go here
-      </SomeOtherComponent> 
+      </SomeOtherComponent>
     );
   }
 }
 
 // 7. SomeOtherComponent needs to be a Class component to receive the ref (unless Hooks - https://reactjs.org/docs/hooks-faq.html#can-i-make-a-ref-to-a-function-component - are used).
 class SomeOtherComponent extends React.Component {
-
   componentDidMount() {
     // Your logic on mount goes here
   }
 
   // 8. BSL will be applied to div below in SomeOtherComponent and persist scrolling for the container
-  render() {   
-    return (
-      <div>
-        some JSX to go here
-      </div> 
-    );
+  render() {
+    return <div ref={this.props.innerRef}>some JSX to go here</div>;
   }
 }
 ```
 
 ##### Vanilla JS
+
 In the html:
+
 ```html
 <head>
   <script src="some-path-where-you-dump-the-javascript-libraries/lib/bodyScrollLock.js"></script>
@@ -206,45 +205,51 @@ bodyScrollLock.clearAllBodyScrollLocks();
 ```
 
 ## Demo
+
 Check out the demo, powered by Now, @ https://bodyscrolllock.now.sh
 
 ## Caveat
-~~On iOS mobile (as is visible in the above demo), if you scroll the body directly even when the scrolling is 
-locked (on iOS), the body scrolls - this is not what this package solves. It solves the typical case where a modal 
-overlays the screen, and scrolling within the modal never causes the body to scroll too (when the top or bottom 
+
+~~On iOS mobile (as is visible in the above demo), if you scroll the body directly even when the scrolling is
+locked (on iOS), the body scrolls - this is not what this package solves. It solves the typical case where a modal
+overlays the screen, and scrolling within the modal never causes the body to scroll too (when the top or bottom
 within the modal has been reached).~~
 
-Since the update from @Neddz, this caveat is no longer valid. iOS mobile behaviour should be the same as 
-other devices (eg. Android Chrome). 
+Since the update from @Neddz, this caveat is no longer valid. iOS mobile behaviour should be the same as
+other devices (eg. Android Chrome).
 
 ## Functions
 
-| Function | Arguments | Return | Description |
-| :--- | :--- | :---: | :--- |
-| `disableBodyScroll` | `targetElement: HTMLElement` <br/>`options: BodyScrollOptions`| `void` | Disables body scroll while enabling scroll on target element |
-| `enableBodyScroll` | `targetElement: HTMLElement` | `void` | Enables body scroll and removing listeners on target element |
-| `clearAllBodyScrollLocks` | `null` | `void` | Clears all scroll locks |
+| Function                  | Arguments                                                      | Return | Description                                                  |
+| :------------------------ | :------------------------------------------------------------- | :----: | :----------------------------------------------------------- |
+| `disableBodyScroll`       | `targetElement: HTMLElement` <br/>`options: BodyScrollOptions` | `void` | Disables body scroll while enabling scroll on target element |
+| `enableBodyScroll`        | `targetElement: HTMLElement`                                   | `void` | Enables body scroll and removing listeners on target element |
+| `clearAllBodyScrollLocks` | `null`                                                         | `void` | Clears all scroll locks                                      |
 
 ## Options
+
 ### reserveScrollBarGap
+
 **optional, default:** false
 
 If the overflow property of the body is set to hidden, the body widens by the width of the scrollbar. This produces an
 unpleasant flickering effect, especially on websites with centered content. If the `reserveScrollBarGap` option is set,
 this gap is filled by a `padding-right` on the body element. If `disableBodyScroll` is called for the last target element,
 or `clearAllBodyScrollLocks` is called, the `padding-right` is automatically reset to the previous value.
-``` js
-import { disableBodyScroll } from 'body-scroll-lock';
-import type { BodyScrollOptions } from 'body-scroll-lock';
+
+```js
+import { disableBodyScroll } from "body-scroll-lock";
+import type { BodyScrollOptions } from "body-scroll-lock";
 
 const options: BodyScrollOptions = {
-    reserveScrollBarGap: true
-}
+  reserveScrollBarGap: true
+};
 
 disableBodyScroll(targetElement, options);
 ```
 
 ### allowTouchMove
+
 **optional, default:** undefined
 
 There are cases where you have called `disableBodyScroll` on an element, but you still want some or all
@@ -252,40 +257,47 @@ children of it to receive touch moves still; or in other words, you want child e
 ignore the fact that a parent element has the body scroll lock set (and hence, not be affected at all by this setting).
 See below for 2 use cases:
 
-##### Simple 
+##### Simple
+
 ```javascript
-  disableBodyScroll(container, {
-    allowTouchMove: el => (el.tagName === 'TEXTAREA')
-  });
+disableBodyScroll(container, {
+  allowTouchMove: el => el.tagName === "TEXTAREA"
+});
 ```
 
 ##### More Complex
+
 Javascript:
+
 ```javascript
-  disableBodyScroll(container, {
-    allowTouchMove: el => {
-      while (el && el !== document.body) {
-        if (el.getAttribute('body-scroll-lock-ignore') !== null) {
-          return true
-        }
-  
-        el = el.parentNode
+disableBodyScroll(container, {
+  allowTouchMove: el => {
+    while (el && el !== document.body) {
+      if (el.getAttribute("body-scroll-lock-ignore") !== null) {
+        return true;
       }
-    },
-  });
+
+      el = el.parentNode;
+    }
+  }
+});
 ```
+
 Html:
+
 ```html
-  <div id="container">
-    <div id="scrolling-map" body-scroll-lock-ignore>
-      ...
-    </div>
+<div id="container">
+  <div id="scrolling-map" body-scroll-lock-ignore>
+    ...
   </div>
+</div>
 ```
 
 ## References
+
 https://medium.com/jsdownunder/locking-body-scroll-for-all-devices-22def9615177
 https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi
 
 ## Changelog
+
 Refer to the [releases](https://github.com/willmcpo/body-scroll-lock/releases) page.


### PR DESCRIPTION
**Objective**:

Update the documentation about React.ref() to pass the props properly through class components.

**Change**:

README.md file is adjusted to explain how to pass the __ref__ between components. 