### PR TITLE
Add setting --body-padding-right to be able to compensate width of fixed elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ other devices (eg. Android Chrome).
 
 If the overflow property of the body is set to hidden, the body widens by the width of the scrollbar. This produces an
 unpleasant flickering effect, especially on websites with centered content. If the `reserveScrollBarGap` option is set,
-this gap is filled by a `padding-right` on the body element. If `disableBodyScroll` is called for the last target element,
-or `clearAllBodyScrollLocks` is called, the `padding-right` is automatically reset to the previous value.
+this gap is filled by a `padding-right` on the body element and `--body-padding-right` on the `documentElement`. Css
+variable let you compensate padding on the fixed elements (e.g. `right: var(--body-padding-right);` instead of `right: 0;`).
+If `disableBodyScroll` is called for the last target element, or `clearAllBodyScrollLocks` is called, the `padding-right`
+and `--body-padding-right` are automatically reset to the previous value.
 ``` js
 import { disableBodyScroll } from 'body-scroll-lock';
 import type { BodyScrollOptions } from 'body-scroll-lock';

--- a/lib/bodyScrollLock.js
+++ b/lib/bodyScrollLock.js
@@ -97,6 +97,7 @@
         if (_reserveScrollBarGap && scrollBarGap > 0) {
           previousBodyPaddingRight = document.body.style.paddingRight;
           document.body.style.paddingRight = scrollBarGap + 'px';
+          document.documentElement.style.setProperty('--body-padding-right', `${scrollBarGap}px`);
         }
       }
 
@@ -114,6 +115,7 @@
     setTimeout(function () {
       if (previousBodyPaddingRight !== undefined) {
         document.body.style.paddingRight = previousBodyPaddingRight;
+        document.documentElement.style.setProperty('--body-padding-right', previousBodyPaddingRight);
 
         // Restore previousBodyPaddingRight to undefined so setOverflowHidden knows it
         // can be set again.


### PR DESCRIPTION
Hi!

Padding-right on the body isn't enough to remove flickering. If you have full-width backgrond or any fixed blocks with `left: 0; right: 0` you still have flickering. I tried to put setting css var after and before calling `disableBodyScroll` but in reason you set padding in `setTimeout`, i still got flickering.
So the only way is to set it immediately after calling `document.body.style.paddingRight=`. When i did it, flickerings disappeared.