### PR TITLE
fix addEventListener not avialable

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -14,7 +14,7 @@ interface Lock {
 
 // Older browsers don't support event options, feature detect it.
 let hasPassiveEvents = false;
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && window.addEventListener) {
   const passiveTestOptions = {
     get passive() {
       hasPassiveEvents = true;


### PR DESCRIPTION
When there is no addEventListener on windows (might happen with server side rendering running in node), this lib throws an exception. This PR adds a check if `addEventListener` is available.

But, it would even be better if no code would be run when the lib is just imported, but rather it is actively used. Then this check would not be necessary.