### PR TITLE
fix isTargetElementTotallyScrolled for mobile

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -108,7 +108,7 @@ const restoreOverflowSetting = () => {
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
 const isTargetElementTotallyScrolled = (targetElement: any): boolean =>
-  targetElement ? targetElement.scrollHeight - targetElement.scrollTop <= targetElement.clientHeight : false;
+  (targetElement.scrollHeight - Math.abs(targetElement.scrollTop)) === targetElement.clientHeight;
 
 const handleScroll = (event: HandleScrollEvent, targetElement: any): boolean => {
   const clientY = event.targetTouches[0].clientY - initialClientY;


### PR DESCRIPTION
Update method logic from MDN. It works better for mobile ios browsers (ex Safari, Chrome)