### PR TITLE
Allow access to native event in 'allowTouchMove'

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -4,7 +4,7 @@
 
 export interface BodyScrollOptions {
   reserveScrollBarGap?: boolean;
-  allowTouchMove?: (el: any) => boolean;
+  allowTouchMove?: (el: any, e: Event) => boolean;
 }
 
 interface Lock {
@@ -41,9 +41,9 @@ let previousBodyPosition;
 let previousBodyPaddingRight;
 
 // returns true if `el` should be allowed to receive touchmove events.
-const allowTouchMove = (el: EventTarget): boolean =>
+const allowTouchMove = (el: EventTarget, e: Event): boolean =>
   locks.some(lock => {
-    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el)) {
+    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el, e)) {
       return true;
     }
 
@@ -57,7 +57,7 @@ const preventDefault = (rawEvent: HandleScrollEvent): boolean => {
   // Recall that we do document.addEventListener('touchmove', preventDefault, { passive: false })
   // in disableBodyScroll - so if we provide this opportunity to allowTouchMove, then
   // the touchmove event on document will break.
-  if (allowTouchMove(e.target)) {
+  if (allowTouchMove(e.target, e)) {
     return true;
   }
 
@@ -158,7 +158,7 @@ const isTargetElementTotallyScrolled = (targetElement: any): boolean =>
 const handleScroll = (event: HandleScrollEvent, targetElement: any): boolean => {
   const clientY = event.targetTouches[0].clientY - initialClientY;
 
-  if (allowTouchMove(event.target)) {
+  if (allowTouchMove(event.target, event)) {
     return false;
   }
 


### PR DESCRIPTION
In order to facilitate more advanced types of event detection / decision-making when allowing `touchmove` events, it is sometimes necessary to have access to the `Event` itself in certain scenarios. For example, detection of Pen / Stylus (see example below), or if you want to use touch X/Y position instead of element.

(Currently B.S.L. breaks all stylus touches, and the only way I've figured out to fix it is to disable BSL on stylus touch events.)

That may be worth a separate issue in itself, but I still think there's value in exposing the native event regardless, since it would allow for much finer grained control over 'allowTouchMove' behavior.

```
        disableBodyScroll(mainElmt, {
          allowTouchMove: (el: HTMLElement, e: Event) => {
            const touch = e as TouchEvent;
            if (touch.touches?.[0]?.touchType === 'stylus') {
              return true;
            }
            // ...
          },
        });
```

The proposed changes should be backwards compatible. And, if it helps, we've been running this in production on over 100,000 devices so far with no issues on any platform/browser.