### PR TITLE
Fix issue in IOS 15 Safari that bottom blank bar will show up

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -113,7 +113,8 @@ const setPositionFixed = () => window.requestAnimationFrame(() => {
     previousBodyPosition = {
       position: document.body.style.position,
       top: document.body.style.top,
-      left: document.body.style.left
+      left: document.body.style.left,
+      height: document.documentElement.style.height
     };
 
     // Update the dom inside an animation frame
@@ -121,6 +122,7 @@ const setPositionFixed = () => window.requestAnimationFrame(() => {
     document.body.style.position = 'fixed';
     document.body.style.top = `${-scrollY}px`;
     document.body.style.left = `${-scrollX}px`;
+    document.documentElement.style.height = '100vh';
 
     setTimeout(() => window.requestAnimationFrame(() => {
       // Attempt to check if the bottom bar appeared due to the position change
@@ -143,6 +145,7 @@ const restorePositionSetting = () => {
     document.body.style.position = previousBodyPosition.position;
     document.body.style.top = previousBodyPosition.top;
     document.body.style.left = previousBodyPosition.left;
+    document.documentElement.style.height = previousBodyPosition.height;
 
     // Restore scroll
     window.scrollTo(x, y);


### PR DESCRIPTION
This is to fix the Safari 15 bottom nav bar issue.
In IOS 15, when user scroll up, the navigation bar in safari may automatically hide. However, when we call the `disableBodyScroll` function, the bottom nav bar will display a blank space as shown in the video below.  
https://user-images.githubusercontent.com/1543197/148535472-3a61e509-ae1d-4c3e-89a7-c6c5e42004b1.mp4

By adding a "height: 100vh" on the root Html tag, this issue can be resolved. 
 