### PR TITLE
fix: prevent restorePositionSetting to run before setPositionFixed

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -133,7 +133,7 @@ const setPositionFixed = () => window.requestAnimationFrame(() => {
   }
 });
 
-const restorePositionSetting = () => {
+const restorePositionSetting = () => window.requestAnimationFrame(() => {
   if (previousBodyPosition !== undefined) {
     // Convert the position from "px" to Int
     const y = -parseInt(document.body.style.top, 10);
@@ -149,7 +149,7 @@ const restorePositionSetting = () => {
 
     previousBodyPosition = undefined;
   }
-};
+});
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
 const isTargetElementTotallyScrolled = (targetElement: any): boolean =>


### PR DESCRIPTION
Fixes issue https://github.com/willmcpo/body-scroll-lock/issues/247#issue-1127285392.