### PR TITLE
HDW-2313 [thru-pilot] fork body-scroll-lock

### DIFF
--- a/src/bodyScrollLock.js
+++ b/src/bodyScrollLock.js
@@ -272,9 +272,11 @@ export const enableBodyScroll = (targetElement: any): void => {
     }
   }
 
-  if (isIosDevice) {
-    restorePositionSetting();
-  } else {
-    restoreOverflowSetting();
+  if (locks.length === 0) {
+    if (isIosDevice) {
+      restorePositionSetting();
+    } else {
+      restoreOverflowSetting();
+    }
   }
 };


### PR DESCRIPTION
fix: restore overflow setting only locks is empty